### PR TITLE
Update environment variable usage in code

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,10 +166,10 @@ If you need to disable authentication (NOT RECOMMENDED), you can set the `DANGER
 DANGEROUSLY_OMIT_AUTH=true npm start
 ```
 
-You can also set the token via the `MCP_PROXY_TOKEN` environment variable when starting the server:
+You can also set the token via the `MCP_PROXY_AUTH_TOKEN` environment variable when starting the server:
 
 ```bash
-MCP_PROXY_TOKEN=$(openssl rand -hex 32) npm start
+MCP_PROXY_AUTH_TOKEN=$(openssl rand -hex 32) npm start
 ```
 
 #### Local-only Binding

--- a/client/bin/start.js
+++ b/client/bin/start.js
@@ -40,7 +40,7 @@ async function startDevServer(serverOptions) {
       ...process.env,
       SERVER_PORT,
       CLIENT_PORT,
-      MCP_PROXY_TOKEN: sessionToken,
+      MCP_PROXY_AUTH_TOKEN: sessionToken,
       MCP_ENV_VARS: JSON.stringify(envVars),
     },
     signal: abort.signal,
@@ -99,7 +99,7 @@ async function startProdServer(serverOptions) {
         ...process.env,
         SERVER_PORT,
         CLIENT_PORT,
-        MCP_PROXY_TOKEN: sessionToken,
+        MCP_PROXY_AUTH_TOKEN: sessionToken,
         MCP_ENV_VARS: JSON.stringify(envVars),
       },
       signal: abort.signal,
@@ -247,8 +247,8 @@ async function main() {
       : "Starting MCP inspector...",
   );
 
-  // Generate session token for authentication
-  const sessionToken = randomBytes(32).toString("hex");
+  // Use provided token from environment or generate a new one
+  const sessionToken = process.env.MCP_PROXY_AUTH_TOKEN || randomBytes(32).toString("hex");
   const authDisabled = !!process.env.DANGEROUSLY_OMIT_AUTH;
 
   const abort = new AbortController();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -92,7 +92,7 @@ const serverTransports: Map<string, Transport> = new Map<string, Transport>(); /
 
 // Use provided token from environment or generate a new one
 const sessionToken =
-  process.env.MCP_PROXY_TOKEN || randomBytes(32).toString("hex");
+  process.env.MCP_PROXY_AUTH_TOKEN || randomBytes(32).toString("hex");
 const authDisabled = !!process.env.DANGEROUSLY_OMIT_AUTH;
 
 // Origin validation middleware to prevent DNS rebinding attacks


### PR DESCRIPTION
Standardize authentication token environment variable to `MCP_PROXY_AUTH_TOKEN`.

This resolves inconsistencies where `MCP_PROXY_TOKEN` was used instead of `MCP_PROXY_AUTH_TOKEN` in server and client startup, and ensures the client correctly reads the environment variable for the token, as reported in the linked GitHub comment.